### PR TITLE
Use Text Nodes

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -425,4 +425,5 @@ export interface ISheet {
   cssRules: any[];
   content: string;
   insertRule(rule: string, index?: number): void;
+  ownerNode: HTMLStyleElement;
 }

--- a/packages/core/tests/index.test.ts
+++ b/packages/core/tests/index.test.ts
@@ -24,7 +24,9 @@ function createFakeEnv(styleTagContents: string[] = [], computedStyles: string[]
       return computedStyles;
     },
     document: {
-      styleSheets,
+      get styleSheets() {
+        return styleSheets.map((styleSheet) => (styleSheet?.ownerNode as HTMLStyleElement)?.sheet as CSSStyleSheet);
+      },
       // Creates a style tag
       createElement() {
         return createStyleTag('');
@@ -159,8 +161,8 @@ describe('createCss: mixed(SSR & Client)', () => {
     expect(styles.length).toBe(3);
     expect(styles[0]).toMatchInlineSnapshot(`
       "/* STITCHES:__variables__ */
-      .theme-0{--colors-red:red;}
-      :root{--colors-red:tomato;}"
+      :root{--colors-red:tomato;}
+      .theme-0{--colors-red:red;}"
     `);
     expect(styles[2]).toMatchInlineSnapshot(`
       "/* STITCHES */
@@ -755,8 +757,8 @@ describe('createCss: mixed(SSR & Client)', () => {
     expect(styles.length).toBe(3);
     expect(styles[0]).toMatchInlineSnapshot(`
       "/* STITCHES:__variables__ */
-      .theme-0{--colors-primary:blue;}
-      :root{--colors-primary:tomato;}"
+      :root{--colors-primary:tomato;}
+      .theme-0{--colors-primary:blue;}"
     `);
     expect(styles[2]).toMatchInlineSnapshot(`
       "/* STITCHES */


### PR DESCRIPTION
This replaces the CSSOM `insertRule` method for the DOM `before` and `after` methods. This change would mean that stitches no longer uses or relies the CSSOM at all.

**Pros**:

- Styles are not lost if the `<style>` is disconnected and reconnected to the document.

**Cons**:

- A subtree MutationObserver watching the `document.head` would pick up style updates.

**Unknowns**:

- There are no benchmarks to yet know if it is faster or slower.
- This code represents a 1:1 change from CSSOM to DOM. It is likely Stitches could implement a more performant API altogether, as it already does for assembling the rules themselves.